### PR TITLE
Corrigindo dockerfile e .gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-DB_HOST=database
-DB_PORT=5432
-DB_USER=postgres
-DB_PASSWORD=fiap123
-DB_NAME=fiap

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-DB_HOST=localhost
-DB_PORT=5433
+DB_HOST=database
+DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=fiap123
 DB_NAME=fiap

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
-DB_HOST=localhost
-DB_PORT=5433
+DB_HOST=database
+DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=fiap123
 DB_NAME=fiap

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 build/
 tmp/
 temp/
+dist/
+.env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,22 +14,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: "postgresql://postgres:fiap123@database:5432/fiap?schema=public"
       JWT_SECRET: "fb1dfe4ac7ff13f00ea1c75fe23d895d95fc993952206207d4336af38c558f55"
     depends_on:
       - database
-      - migrations
     restart: on-failure
-  migrations:
-    build:
-      context: .
-      dockerfile: ./docker/app.dockerfile
-      target: prisma-migrate
-    entrypoint: ["npx", "prisma", "db", "push"]
-    depends_on:
-      - database
-    restart: on-failure
-    environment:
-      DATABASE_URL: "postgresql://postgres:fiap123@database:5432/fiap?schema=public"
     #web:
   #  image: nginx

--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -1,14 +1,4 @@
-FROM node:20.9.0 AS prisma-migrate
-
-WORKDIR /app
-
-COPY prisma ./prisma
-COPY package*.json ./
-
-RUN npm install
-RUN npx prisma generate
-
-FROM node:20.9.0 AS build
+FROM node:20.10.0 AS build
 
 WORKDIR /app
 COPY package*.json ./
@@ -17,19 +7,19 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM node:20.9.0 AS production
+FROM node:20.10.0 AS production
 
 WORKDIR /app
 
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/dist ./dist
-COPY --from=prisma-migrate /app/node_modules/.prisma/client ./node_modules/.prisma/client
 
 RUN npm install --omit=dev
+
 EXPOSE 3000
 CMD ["npm", "run", "start:prod"]
 
-FROM node:20.9.0 AS dev
+FROM node:20.10.0 AS dev
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
Arquivos com informações confidenciais não devem ser versionados. O `.env` foi removido.

Dockerfile atualizado para não utilizar prisma mais.